### PR TITLE
Bugfix for extract-operator-bundle.yml bundle sanity checks causing syntax errors

### DIFF
--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -26,23 +26,17 @@
 - name: "Check if the operators.operatorframework.io.bundle.channels.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operators.operatorframework.io.bundle.channels.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when: >
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1']
-    != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1']
 
 - name: "Check if the operators.operatorframework.io.bundle.manifests.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operators.operatorframework.io.bundle.manifests.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when: >
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.manifests.v1']
-    != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.manifests.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.manifests.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.manifests.v1']
 
 - name: "Check if the operators.operatorframework.io.bundle.mediatype.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operatorframework.io.bundle.mediatype.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when: >
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.mediatype.v1']
-    != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.mediatype.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.mediatype.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.mediatype.v1']
 
 - name: "Check if the operators.operatorframework.io.bundle.mediatype.v1 is set to the expected value"
   fail:
@@ -53,13 +47,9 @@
 - name: "Check if the operators.operatorframework.io.bundle.metadata.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operatorframework.io.bundle.metadata.v1 value in the annotations yaml doesn't match the corresponding bundle image label!!"
-  when: >
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.metadata.v1']
-    != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.metadata.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.metadata.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.metadata.v1']
 
 - name: "Check if the operators.operatorframework.io.bundle.package.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operatorframework.io.bundle.package.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when: >
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.package.v1']
-    != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.package.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1']

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -149,9 +149,8 @@
       mode: 0644
 
   - name: "Sanity check the operator bundle's information"
-    include_tasks: "bundle_sanity_checks.yml"
-    when:
-      bundle_sanity_checks|bool
+    include_tasks: bundle_sanity_checks.yml
+    when: bundle_sanity_checks|bool
 
   rescue:
 


### PR DESCRIPTION
$subject
Fixes failures caused inside the extract-operator-bundle. 
