### PR TITLE
Update the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 filter_plugins/__pycache__
 filter_plugins/*.pyc
 .idea/
+site/


### PR DESCRIPTION
Likhitha added a documentation website for this repository. This documentation gets compiled by the `mkdocs` utility into the `site` folder, similar to the community operators repository. This PR adds the `site` folder to the `.gitignore`, so that we don't accidentally commit the compile documentation. 