### PR TITLE
fix: propagates test script error code correctly

### DIFF
--- a/upstream/test/test.sh
+++ b/upstream/test/test.sh
@@ -138,17 +138,20 @@ function run() {
                 echo "#${v#*--}"
                 set -o pipefail
                 "$@" | tee -a $OP_TEST_LOG_DIR/log.out
-                [[ $? -eq 0 ]] || { echo -e "\nFailed with rc=$? !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $?; }
+                exit_code=$?
+                if [ $exit_code -ne 0 ]; then echo -e "\nFailed with rc=$exit_code !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $exit_code; fi
                 set +o pipefail
         elif [[ $OP_TEST_DEBUG -ge 1 ]] ; then
                 set -o pipefail
                 "$@" | tee -a $OP_TEST_LOG_DIR/log.out
-                [[ $? -eq 0 ]] || { echo -e "\nFailed with rc=$? !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $?; }
+                exit_code=$?
+                if [ $exit_code -ne 0 ]; then echo -e "\nFailed with rc=$exit_code !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $exit_code; fi
                 set +o pipefail
         else
                 set -o pipefail
                 "$@" | tee -a $OP_TEST_LOG_DIR/log.out >/dev/null 2>&1
-                [[ $? -eq 0 ]] || { echo -e "\nFailed with rc=$? !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $?; }
+                exit_code=$?
+                if [ $exit_code -ne 0 ]; then echo -e "\nFailed with rc=$exit_code !!!\nLogs are in '$OP_TEST_LOG_DIR/log.out'."; exit $exit_code; fi
                 set +o pipefail
         fi
 }


### PR DESCRIPTION
Right now if test script fails at some point it will log error but exit with `0`. This is because it will take `$?` return code from echo which prints the original error code.

This PR keeps actual error code in the variable to avoid this issue.