### PR TITLE
[upstream_community]: Update OLM to v1.19.1

### DIFF
--- a/upstream/local.yml
+++ b/upstream/local.yml
@@ -35,7 +35,7 @@
     kind_kube_version: v1.21.1
     operator_sdk_version: v1.8.0
     operator_courier_version: 2.1.11
-    olm_version: 0.17.0
+    olm_version: 0.19.1
     opm_version: v1.19.1
     oc_version: 4.3.5
     go_version: 1.13.7


### PR DESCRIPTION
Using a newer OLM version to lift the bundle size limitation of 1MB.

Signed-off-by: orenc1 <ocohen@redhat.com>