### PR TITLE
[CVP-2565] Upgrade operator-sdk to v1.16.0 for operator bundle tes…

### DIFF
--- a/Dockerfiles/ci/Dockerfile
+++ b/Dockerfiles/ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:33
 WORKDIR /project
-ARG OPERATOR_SDK_VERSION=v1.13.1
+ARG OPERATOR_SDK_VERSION=v1.16.0
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac);\
     export OS=$(uname | awk '{print tolower($0)}');\
     export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/;\

--- a/Dockerfiles/midstream/Dockerfile
+++ b/Dockerfiles/midstream/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.fedoraproject.org/fedora:33
-ARG OPERATOR_SDK_VERSION=v1.13.1
+ARG OPERATOR_SDK_VERSION=v1.16.0
 ARG UMOCI_VERSION=v0.4.5
 ENV ANSIBLE_CONFIG=/project/operator-test-playbooks/Dockerfiles/midstream/
 ENV ANSIBLE_LOCAL_TEMP=/tmp/

--- a/roles/install_operator_prereqs/defaults/main.yml
+++ b/roles/install_operator_prereqs/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 testing_bin_path: /tmp/cvp/bin
-operator_sdk_version: v1.13.1
+operator_sdk_version: v1.16.0
 oc_version: 4.4.13  # The catalog initialization test requires oc v4.4+
 operator_courier_version: 2.1.9
 go_version: 1.13.7

--- a/roles/operator_bundle_scorecard_tests/files/scorecard-basic-config.yml
+++ b/roles/operator_bundle_scorecard_tests/files/scorecard-basic-config.yml
@@ -7,14 +7,14 @@ metadata:
 stages:
   - parallel: true
     tests:
-      - image: quay.io/operator-framework/scorecard-test:v1.13.1
+      - image: quay.io/operator-framework/scorecard-test:v1.16.0
         entrypoint:
           - scorecard-test
           - basic-check-spec
         labels:
           suite: basic
           test: basic-check-spec-test
-      - image: quay.io/operator-framework/scorecard-test:v1.13.1
+      - image: quay.io/operator-framework/scorecard-test:v1.16.0
         entrypoint:
           - scorecard-test
           - olm-bundle-validation

--- a/upstream/local.yml
+++ b/upstream/local.yml
@@ -34,7 +34,7 @@
     offline_cataloger_bin_path: "offline-cataloger"
     kind_version: v0.9.0
     kind_kube_version: v1.21.1
-    operator_sdk_version: v1.13.1
+    operator_sdk_version: v1.16.0
     operator_courier_version: 2.1.11
     olm_version: 0.17.0
     opm_version: v1.17.0


### PR DESCRIPTION
From CVP-2565 deliverables, this PR takes care of the second one:

- Update the operator-utils container to use operator-sdk >= v1.16.0
- **Update the operator-test-playbooks to use operator-sdk >= v1.16.0**
- Update the operator-sdk image used in the Prow workflow to use operator-sdk >= v1.16.
- Update the quay.io/operator-framework/scorecard-test images to use v1.16.0 tag
- Update the image source test to account for the new images