### PR TITLE
Add check for openshift subscription

### DIFF
--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -104,12 +104,13 @@
     set_fact:
       csv_vars: "{{ csv_data.stdout }}"
 
-  - name: "Determine and set fact for operator specific information - name, pod name, container name and capabilities"
+  - name: "Determine and set fact for operator specific information - name, pod name, container name, capabilities, and subscription"
     set_fact:
       current_csv: "{{ (csv_vars | from_yaml).metadata.name }}"
       operator_pod_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].name }}"
       operator_container_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].spec.template.spec.containers[0].name }}"
       operator_capabilities: "{{ (csv_vars | from_yaml).metadata.annotations.capabilities }}"
+      operator_valid_subscription: "{{ (csv_vars | from_yaml).metadata.annotations['operators.openshift.io/valid-subscription'] | default([]) }}"
 
   - name: "Determine operator_allnamespaces_support"
     set_fact:

--- a/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
+++ b/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
@@ -13,6 +13,14 @@ operator_allnamespaces_support: {{ operator_allnamespaces_support }}
 operator_ownnamespace_support: {{ operator_ownnamespace_support }}
 operator_singlenamespace_support: {{ operator_singlenamespace_support }}
 operator_multinamespace_support: {{ operator_multinamespace_support }}
+{% if operator_valid_subscription|length < 1 %}
+operator_valid_subscription: []
+{% else %}
+operator_valid_subscription:
+{% for valid_subscription in operator_valid_subscription %}
+  - {{ valid_subscription }}
+{% endfor %}
+{% endif %}
 {% if crd_paths|length < 1 %}
 crd_paths: []
 {% else %}


### PR DESCRIPTION
Added code to parse the `operators.openshift.io/valid-subscription`  annotation from the CSV and add this information to the `parsed_operator_data.yml` artifact.