### PR TITLE
Parse OpenShift subscription annotation from CSV

### DIFF
--- a/Dockerfiles/ci/Dockerfile
+++ b/Dockerfiles/ci/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /project
 ARG OPERATOR_SDK_VERSION=v1.16.0
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac);\
     export OS=$(uname | awk '{print tolower($0)}');\
-    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/;\
+    export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION;\
     curl -L -o /usr/local/bin/operator-sdk ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} && \
     chmod a+x /usr/local/bin/operator-sdk && \
     curl -fL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 && \

--- a/Dockerfiles/ci/run_tests.py
+++ b/Dockerfiles/ci/run_tests.py
@@ -165,6 +165,60 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
         self.assertIn("Invalid semver in ocpfournine", playbook_command.stdout.decode("utf-8"))
         self.assertIn("Error collecting OCP version range from Pyxis", playbook_command.stdout.decode("utf-8"))
 
+    def test_extract_operator_bundle_no_subscription(self):
+        operator_work_dir = "{}/test_extract_operator_bundle_no_subscription".format(self.test_dir)
+        work_dir = operator_work_dir
+        operator_dir = "{}/test-operator".format(operator_work_dir)
+        operator_bundle_dir = "{}/operator-bundle".format(operator_work_dir)
+        bundle_image = "quay.io/cvpops/test-operator:test-430-channel-positive-v1"
+        exec_cmd = "ansible-playbook -vvv -i localhost, --connection local \
+                    operator-test-playbooks/extract-operator-bundle.yml \
+                    -e 'operator_dir={operator_dir}' \
+                    -e 'bundle_image={bundle_image}' \
+                    -e 'operator_work_dir={operator_work_dir}' \
+                    -e 'operator_bundle_dir={operator_bundle_dir}' \
+                    -e 'work_dir={work_dir}'".format(operator_dir=operator_dir,
+                                                     operator_work_dir=operator_work_dir,
+                                                     operator_bundle_dir=operator_bundle_dir,
+                                                     bundle_image=bundle_image,
+                                                     work_dir=work_dir)
+        playbook_command = subprocess.run(exec_cmd, shell=True)
+
+        print(playbook_command.returncode)
+        self.assertTrue(playbook_command.returncode == 0)
+        self.assertTrue(path.exists("{}/parsed_operator_data.yml".format(work_dir)))
+        with open("{}/parsed_operator_data.yml".format(work_dir), "r") as fd:
+            parsed_output = fd.read()
+            print(parsed_output)
+            self.assertIn('operator_valid_subscription: []', parsed_output)
+
+    def test_extract_operator_bundle_with_subscription(self):
+        operator_work_dir = "{}/test_extract_operator_bundle_with_subscription".format(self.test_dir)
+        work_dir = operator_work_dir
+        operator_dir = "{}/test-operator".format(operator_work_dir)
+        operator_bundle_dir = "{}/operator-bundle".format(operator_work_dir)
+        bundle_image = "quay.io/cvpops/test-operator:with-subscription"
+        exec_cmd = "ansible-playbook -vvv -i localhost, --connection local \
+                    operator-test-playbooks/extract-operator-bundle.yml \
+                    -e 'operator_dir={operator_dir}' \
+                    -e 'bundle_image={bundle_image}' \
+                    -e 'operator_work_dir={operator_work_dir}' \
+                    -e 'operator_bundle_dir={operator_bundle_dir}' \
+                    -e 'work_dir={work_dir}'".format(operator_dir=operator_dir,
+                                                     operator_work_dir=operator_work_dir,
+                                                     operator_bundle_dir=operator_bundle_dir,
+                                                     bundle_image=bundle_image,
+                                                     work_dir=work_dir)
+        playbook_command = subprocess.run(exec_cmd, shell=True)
+
+        print(playbook_command.returncode)
+        self.assertTrue(playbook_command.returncode == 0)
+        self.assertTrue(path.exists("{}/parsed_operator_data.yml".format(work_dir)))
+        with open("{}/parsed_operator_data.yml".format(work_dir), "r") as fd:
+            parsed_output = fd.read()
+            print(parsed_output)
+            self.assertIn('operator_valid_subscription:\n  - "Test Subscription One"\n  - "Test Subscription Two"', parsed_output)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -104,12 +104,13 @@
     set_fact:
       csv_vars: "{{ csv_data.stdout }}"
 
-  - name: "Determine and set fact for operator specific information - name, pod name, container name and capabilities"
+  - name: "Determine and set fact for operator specific information - name, pod name, container name, capabilities, and subscription"
     set_fact:
       current_csv: "{{ (csv_vars | from_yaml).metadata.name }}"
       operator_pod_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].name }}"
       operator_container_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].spec.template.spec.containers[0].name }}"
       operator_capabilities: "{{ (csv_vars | from_yaml).metadata.annotations.capabilities }}"
+      operator_valid_subscription: "{{ ((csv_vars | from_yaml).metadata.annotations['operators.openshift.io/valid-subscription'] | default('[]')) | from_json }}"
 
   - name: "Determine operator_allnamespaces_support"
     set_fact:
@@ -147,6 +148,14 @@
       src: "parsed_operator_data.yml.j2"
       dest: "{{ work_dir }}/parsed_operator_data.yml"
       mode: 0644
+
+  - name: "Cat parsed_operator_data.yml"
+    shell: "cat {{ work_dir }}/parsed_operator_data.yml"
+    register: parsed_data_file
+
+  - name: "Print contents of parsed_operator_data.yml"
+    debug:
+      msg: "{{ parsed_data_file.stdout_lines }}"
 
   - name: "Sanity check the operator bundle's information"
     include_tasks: bundle_sanity_checks.yml

--- a/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
+++ b/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
@@ -13,6 +13,14 @@ operator_allnamespaces_support: {{ operator_allnamespaces_support }}
 operator_ownnamespace_support: {{ operator_ownnamespace_support }}
 operator_singlenamespace_support: {{ operator_singlenamespace_support }}
 operator_multinamespace_support: {{ operator_multinamespace_support }}
+{% if operator_valid_subscription|length < 1 %}
+operator_valid_subscription: []
+{% else %}
+operator_valid_subscription:
+{% for valid_subscription in operator_valid_subscription %}
+  - "{{ valid_subscription }}"
+{% endfor %}
+{% endif %}
 {% if crd_paths|length < 1 %}
 crd_paths: []
 {% else %}


### PR DESCRIPTION
Added code to parse `operators.openshift.io/valid-subscription` from CSV annotations.
