### PR TITLE
Revert "Bump opm 1.21.0"

### DIFF
--- a/upstream/local.yml
+++ b/upstream/local.yml
@@ -40,7 +40,7 @@
     operator_sdk_version: v1.19.1
     operator_courier_version: 2.1.11
     olm_version: 0.20.0
-    opm_version: v1.21.0
+    opm_version: v1.19.5
     k8s_community_bundle_validator_version: v0.1.0
     oc_version: 4.3.5
     go_version: 1.13.7


### PR DESCRIPTION
Reverts redhat-openshift-ecosystem/operator-test-playbooks#342