### PR TITLE
[CVP-3217] Fix issue parsing current channel

### DIFF
--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -52,7 +52,7 @@
 
   - name: "Set the current channel to the first value from the operators.operatorframework.io.bundle.channels.v1 label"
     set_fact:
-      current_channel: "{{ channels[0] }}"
+      current_channel: "{{ channels[0] | string }}"
 
   - name: "Set is_backport according to the com.redhat.delivery.backport label, if it's missing, an empty is_backport means not set."
     set_fact:


### PR DESCRIPTION
This ensures that when the current channel is entirely numerical, for example like "4.10", it does not get truncated to "4.1".