### PR TITLE
[CVP-3364] Ensure default channel parsed as string

### DIFF
--- a/Dockerfiles/ci/README.md
+++ b/Dockerfiles/ci/README.md
@@ -25,9 +25,7 @@ podman run -it -v $PWD:/project/operator-test-playbooks -v ./Dockerfiles/ci/exam
 
 ---
 ** NOTE **
-
-currently there is only one test inside the container image i.e., test_for_report_failed_empty_alm_examples
-In order to add more tests please add more functions to run_tests.py inside the Dockerfiles/ci folder in operator-test-playbooks
+New tests can be created by adding functions to `Dockerfiles/ci/run_tests.py`.
 
 ---
 

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -61,7 +61,7 @@
 
   - name: "Set default_channel according to the operators.operatorframework.io.bundle.channel.default.v1 label if present."
     set_fact:
-      default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
+      default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] | string }}"
     when: skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] is defined
 
   - name: "Determine paths with kind ClusterServiceVersion"


### PR DESCRIPTION
- Fixed playbook to ensure that default channel is parsed as a string, the same as was done in #374 for current channel.