### PR TITLE
[CVP-3881] Use string for infrastructure feature annotations

### DIFF
--- a/Dockerfiles/ci/run_tests.py
+++ b/Dockerfiles/ci/run_tests.py
@@ -274,7 +274,7 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
             parsed_output = fd.read()
             print(parsed_output)
             self.assertNotIn("operator_feature_disconnected", parsed_output)
-            self.assertNotIn("operator_feature_fipsmode", parsed_output)
+            self.assertNotIn("operator_feature_fips_compliant", parsed_output)
             self.assertNotIn("operator_feature_proxy_aware", parsed_output)
             self.assertNotIn("operator_feature_cnf", parsed_output)
             self.assertNotIn("operator_feature_cni", parsed_output)
@@ -289,7 +289,7 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
         work_dir = operator_work_dir
         operator_dir = "{}/test-operator".format(operator_work_dir)
         operator_bundle_dir = "{}/operator-bundle".format(operator_work_dir)
-        bundle_image = "quay.io/cvpops/test-operator:with-infrastructure-features"
+        bundle_image = "quay.io/cvpops/test-operator:with-infrastructure-features-as-strings"
         exec_cmd = "ansible-playbook -vvv -i localhost, --connection local \
                     operator-test-playbooks/extract-operator-bundle.yml \
                     -e 'operator_dir={operator_dir}' \
@@ -309,16 +309,16 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
         with open("{}/parsed_operator_data.yml".format(work_dir), "r") as fd:
             parsed_output = fd.read()
             print(parsed_output)
-            self.assertIn('operator_feature_disconnected: False', parsed_output)
-            self.assertIn('operator_feature_fipsmode: True', parsed_output)
-            self.assertIn('operator_feature_proxy_aware: False', parsed_output)
-            self.assertIn('operator_feature_cnf: False', parsed_output)
-            self.assertIn('operator_feature_cni: True', parsed_output)
-            self.assertIn('operator_feature_csi: True', parsed_output)
-            self.assertIn('operator_feature_tls_profiles: True', parsed_output)
-            self.assertIn('operator_feature_token_auth_aws: False', parsed_output)
-            self.assertIn('operator_feature_token_auth_azure: False', parsed_output)
-            self.assertIn('operator_feature_token_auth_gcp: False', parsed_output)
+            self.assertIn('operator_feature_disconnected: "False"', parsed_output)
+            self.assertIn('operator_feature_fips_compliant: "True"', parsed_output)
+            self.assertIn('operator_feature_proxy_aware: "False"', parsed_output)
+            self.assertIn('operator_feature_cnf: "False"', parsed_output)
+            self.assertIn('operator_feature_cni: "True"', parsed_output)
+            self.assertIn('operator_feature_csi: "True"', parsed_output)
+            self.assertIn('operator_feature_tls_profiles: "True"', parsed_output)
+            self.assertIn('operator_feature_token_auth_aws: "False"', parsed_output)
+            self.assertIn('operator_feature_token_auth_azure: "False"', parsed_output)
+            self.assertIn('operator_feature_token_auth_gcp: "False"', parsed_output)
 
 if __name__ == '__main__':
     unittest.main()

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -115,7 +115,7 @@
   - name: "Determine and set fact for infrastructure-related annotations"
     set_fact:
       operator_feature_disconnected: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/disconnected'] | default(omit) }}"
-      operator_feature_fipsmode: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/fipsmode'] | default(omit) }}"
+      operator_feature_fips_compliant: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/fips-compliant'] | default(omit) }}"
       operator_feature_proxy_aware: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/proxy-aware'] | default(omit) }}"
       operator_feature_cnf: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/cnf'] | default(omit) }}"
       operator_feature_cni: "{{ (csv_vars | from_yaml).metadata.annotations['features.operators.openshift.io/cni'] | default(omit) }}"

--- a/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
+++ b/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
@@ -31,32 +31,32 @@ crd_paths:
 {% endif %}
 ocp_versions: "{{ ocp_versions }}"
 {% if operator_feature_disconnected is defined %}
-operator_feature_disconnected: {{ operator_feature_disconnected }}
+operator_feature_disconnected: "{{ operator_feature_disconnected }}"
 {% endif %}
-{% if operator_feature_fipsmode is defined %}
-operator_feature_fipsmode: {{ operator_feature_fipsmode }}
+{% if operator_feature_fips_compliant is defined %}
+operator_feature_fips_compliant: "{{ operator_feature_fips_compliant }}"
 {% endif %}
 {% if operator_feature_proxy_aware is defined %}
-operator_feature_proxy_aware: {{ operator_feature_proxy_aware }}
+operator_feature_proxy_aware: "{{ operator_feature_proxy_aware }}"
 {% endif %}
 {% if operator_feature_cnf is defined %}
-operator_feature_cnf: {{ operator_feature_cnf }}
+operator_feature_cnf: "{{ operator_feature_cnf }}"
 {% endif %}
 {% if operator_feature_cni is defined %}
-operator_feature_cni: {{ operator_feature_cni }}
+operator_feature_cni: "{{ operator_feature_cni }}"
 {% endif %}
 {% if operator_feature_csi is defined %}
-operator_feature_csi: {{ operator_feature_csi }}
+operator_feature_csi: "{{ operator_feature_csi }}"
 {% endif %}
 {% if operator_feature_tls_profiles is defined %}
-operator_feature_tls_profiles: {{ operator_feature_tls_profiles }}
+operator_feature_tls_profiles: "{{ operator_feature_tls_profiles }}"
 {% endif %}
 {% if operator_feature_token_auth_aws is defined %}
-operator_feature_token_auth_aws: {{ operator_feature_token_auth_aws }}
+operator_feature_token_auth_aws: "{{ operator_feature_token_auth_aws }}"
 {% endif %}
 {% if operator_feature_token_auth_azure is defined %}
-operator_feature_token_auth_azure: {{ operator_feature_token_auth_azure }}
+operator_feature_token_auth_azure: "{{ operator_feature_token_auth_azure }}"
 {% endif %}
 {% if operator_feature_token_auth_gcp is defined %}
-operator_feature_token_auth_gcp: {{ operator_feature_token_auth_gcp }}
+operator_feature_token_auth_gcp: "{{ operator_feature_token_auth_gcp }}"
 {% endif %}


### PR DESCRIPTION
1. Changed boolean to string for new infrastructure feature annotations
2. Changed `features.operators.openshift.io/fipsmode` to `features.operators.openshift.io/fips-compliant` as per new requirenments in https://issues.redhat.com/browse/PORTENABLE-525