### PR TITLE
[CVP-3890] Do string comparison of channels.v1 label

### DIFF
--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -29,7 +29,7 @@
 - name: "Check if the operators.operatorframework.io.bundle.channels.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operators.operatorframework.io.bundle.channels.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when: annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1']
+  when: annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1'] | string != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1'] | string
 
 - name: "Check if the operators.operatorframework.io.bundle.manifests.v1 from annotation.yaml matches the bundle image label"
   fail:


### PR DESCRIPTION
Do string comparison of `operators.operatorframework.io.bundle.channels.v1` label from `annotations.yaml`.