### PR TITLE
[ISV-5091] Optimize container tool storage configuration

### DIFF
--- a/upstream/roles/build_app_registry/defaults/main.yml
+++ b/upstream/roles/build_app_registry/defaults/main.yml
@@ -3,6 +3,7 @@ testing_bin_path: "{{ work_dir }}/bin"
 opm_bin_path: "{{ testing_bin_path }}/opm"
 bundle_export_dir_app_registry: "{{ work_dir }}/app_registry/upstream-community-operators"
 container_tool: "docker"
+container_tool_extra_params: ""
 opm_container_tool: "docker"
 opm_container_tool_index: "docker"
 container_push_extra: ""
@@ -12,3 +13,4 @@ app_registry_build_dir: "{{ catalog_repo_dir }}"
 app_registry_build_file: "upstream.Dockerfile"
 default_retries: 5
 default_delay: 10
+optimize_build_storage: false

--- a/upstream/roles/build_app_registry/tasks/main.yml
+++ b/upstream/roles/build_app_registry/tasks/main.yml
@@ -58,8 +58,46 @@
 
 - name: "Building and pushing app registry"
   block:
+    - name: "Setting up optimized container tool storage configuration (/mnt/storage)"
+      become: true
+      file:
+        path: "/mnt/storage"
+        state: "directory"
+        owner: "{{ ansible_user_uid }}"
+        group: "{{ ansible_user_gid }}"
+    - name: "Setting up optimized container tool storage configuration (/mnt/rundir)"
+      become: true
+      file:
+        path: "/mnt/rundir"
+        state: "directory"
+        owner: "{{ ansible_user_uid }}"
+        group: "{{ ansible_user_gid }}"
+    - name: "Setting up optimized container tool storage configuration (/mnt/tmp)"
+      become: true
+      file:
+        path: "/mnt/tmp"
+        state: "directory"
+        mode: "1777"
+    - name: "Setting up optimized container tool storage configuration (storage.conf)"
+      become: true
+      copy:
+        content: |
+          [storage]
+          graphroot = "/mnt/storage"
+          driver = "overlay"
+          runroot = "/mnt/rundir"
+        dest: "/usr/share/containers/storage.conf"
+    - name: "Setting up optimized container tool storage configuration (containers.conf)"
+      become: true
+      copy:
+        content: |
+          [engine]
+          env = ["TMPDIR=/mnt/tmp"]
+        dest: "/etc/containers/containers.conf"
+      when: optimize_build_storage|bool == true
+
     - name: "Build app registry image '{{ app_registry_image }}' using '{{ app_registry_build_file }}'"
-      shell: "{{ container_tool }} build --no-cache -t {{ app_registry_image }} -f {{ app_registry_build_dir }}/{{ app_registry_build_file }} {{ bundle_export_dir_app_registry | dirname }}"
+      shell: "{{ container_tool }} build {{ container_tool_extra_params }} --no-cache -t {{ app_registry_image }} -f {{ app_registry_build_dir }}/{{ app_registry_build_file }} {{ bundle_export_dir_app_registry | dirname }}"
 
     - name: "Push app registry image '{{ app_registry_image }}'"
       shell: "{{ container_tool }} push {{ container_push_extra }} {{ app_registry_image }}"


### PR DESCRIPTION
**TLDR**: specifying a different storage driver (overlay) from the default one (VFS) fixed the issue as it is more optimized for storage.

- Adds a new Ansible step controlled by the boolean variable `optimize_build_storage` to apply a storage configuration that saves disk space and make podman build execution safer. Take into account that the podman instance used here is NOT the same as the one we handle in community-operators-pipeline. The only way to customize it was to edit it straight into the Ansible config that invokes it.
- Adds extra parameters variable to podman build command. This allows to easily add new configuration options and for debugging just editing [this list](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline/blob/e1de0e6d6ebddc0f4fc6f7f4cec2a6f6cd57c926/ci/scripts/opp.sh#L45). The real fix to the issue is to setup overlay as storage driver with `--storage-driver`.

Example start-to-end pipeline run with this changes being applied successfully: https://github.com/k8s-operatorhub/community-operators/actions/runs/10237309646/job/28322358625

Some references:
- https://github.com/containers/buildah/issues/4423
- https://github.com/containers/buildah/issues/2850