### PR TITLE
fix op_info_consistency task

### DIFF
--- a/upstream/roles/operator_info_load/tasks/op_info_consistency.yml
+++ b/upstream/roles/operator_info_load/tasks/op_info_consistency.yml
@@ -24,14 +24,14 @@
 - name: "Show difference if failing"
   debug:
     var: oi_check_operators_artifact
-  when: oi_check_operators_artifact|difference(oi_check_operator_info_keys)
+  when: (oi_check_operators_artifact|difference(oi_check_operator_info_keys))|length > 0
 
 - name: "Show difference if failing II"
   debug:
     var: oi_check_operator_info_keys
-  when: oi_check_operators_artifact|difference(oi_check_operator_info_keys)
+  when: (oi_check_operators_artifact|difference(oi_check_operator_info_keys))|length > 0
 
 - name: "Failing"
   fail:
     msg: "Found a difference between operators artifact and operator_info [FAIL]"
-  when: oi_check_operators_artifact|difference(oi_check_operator_info_keys)
+  when: (oi_check_operators_artifact|difference(oi_check_operator_info_keys))|length > 0


### PR DESCRIPTION
### Description
Fix the `op_info_consistency` task that was using old Ansible pattern and it was failing with the following error:
```
 [ERROR]: Task failed: Conditional result (False) was derived from value of type 'list' at '/home/runner/.ansible/pull/runnervm3ublj/upstream/roles/operator_info_load/tasks/op_info_consistency.yml:27:9'. Conditionals must have a boolean result.

Task failed.
Origin: /home/runner/.ansible/pull/runnervm3ublj/upstream/roles/operator_info_load/tasks/op_info_consistency.yml:24:3

22     oi_check_operator_info_keys: "{{ op_info.keys() | list }}"
23
24 - name: "Show difference if failing"
     ^ column 3
```

Now it's added `length` to transform it into a `boolean`.
I was able to reproduced the issue locally and confirmed the code changes fix it.

The output:
```
TASK [Print final 'op_info'] **********************************************************************************************************************************************************
ok: [localhost] => {
    "op_info": {
        "operator1": {
            "versions": [
                "1.0.0"
            ]
        },
        "operator2": {
            "versions": [
                "2.0.0"
            ]
        }
    }
}

TASK [Silen further op_info print] ****************************************************************************************************************************************************
ok: [localhost] => {"ansible_facts": {"op_info_printed_already": true}, "changed": false}

TASK [Clean up test files] ************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "path": "/tmp/test-operator-info", "state": "absent"}

PLAY RECAP ****************************************************************************************************************************************************************************
localhost                  : ok=19   changed=2    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0  
```