### PR TITLE
[ISV-6393] Update playbooks for ansible 2.19

### DIFF
--- a/.github/workflows/yaml_and_ansible_linting.yml
+++ b/.github/workflows/yaml_and_ansible_linting.yml
@@ -22,16 +22,12 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: "Ansible-lint"
-      # Install ansible-lint(5.0.6) together with yamllint(1.26.0) and run the linting on the whole repo
+      # Install ansible-lint(25.9.2) together with yamllint(1.34.0) and run the linting on the whole repo
         run: |
+          set -e
           python -m pip install ansible
-          pip install ansible-lint==5.0.6 yamllint==1.26.0
-          ansible-lint -c ansible-lint.yml *.yml |& tee lint-output.txt
-          if  egrep -i '^(warning.*listing.*violation\(s)\)' lint-output.txt; then
-              exit 1
-          else
-              exit 0
-          fi
+          pip install ansible-lint==25.9.2 yamllint==1.34.0
+          ansible-lint -c .ansible-lint *.yml
 
 
       - name: "Yaml-lint"

--- a/local-test-operator-bundle.yml
+++ b/local-test-operator-bundle.yml
@@ -24,7 +24,7 @@
         umoci_bin_path: "{{ testing_bin_path }}/umoci"
         opm_bin_path: "{{ testing_bin_path }}/opm"
         operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
-        oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+        oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
 
 
     - name: "Install operator testing prerequisites"

--- a/local-test-operator.yml
+++ b/local-test-operator.yml
@@ -39,7 +39,7 @@
         scorecard_cr_dir: "{{ work_dir }}/scorecard-cr-files"
         kube_objects_dir: "{{ work_dir }}/kube_objects"
         testing_bin_path: "{{ work_dir }}/bin"
-        oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+        oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
         jq_bin_path: "{{ testing_bin_path }}/jq"
         yq_bin_path: "{{ testing_bin_path }}/yq"
         go_bin_path: "{{ testing_bin_path }}/go/bin/go"

--- a/roles/inject_openshift_kube_objects/tasks/main.yml
+++ b/roles/inject_openshift_kube_objects/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: "Read yaml file content to get the namespace"
   set_fact:
-    content="{{ lookup('file', '{{ kube_objects_dir }}/kube_objects.yaml') | from_yaml }}"
+    content: "{{ lookup('file', kube_objects_dir + '/kube_objects.yaml') | from_yaml }}"
   no_log: true
   ignore_errors: true
 

--- a/roles/install_operator_prereqs/tasks/main.yml
+++ b/roles/install_operator_prereqs/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: "Set basic facts"
   set_fact:
     operator_sdk_bin_path: "{{ testing_bin_path}}/operator-sdk"
-    oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+    oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
     jq_bin_path: "{{ testing_bin_path }}/jq"
     yq_bin_path: "{{ testing_bin_path }}/yq"
     go_bin_path: "{{ testing_bin_path }}/go/bin/go"

--- a/upstream/local-deploy-operator-bundle.yml
+++ b/upstream/local-deploy-operator-bundle.yml
@@ -44,7 +44,7 @@
         opm_bin_path: "{{ testing_bin_path }}/opm"
         catalog_repo_dir: /tmp/community-operators-for-catalog
         operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
-        oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+        oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
         # mirror_apply: true
         doic_skip_file_check: false
         operator_upgrade_testing_disabled: false

--- a/upstream/local.yml
+++ b/upstream/local.yml
@@ -170,7 +170,7 @@
         run_manifest_test: "{{ run_manifest_test | default(false) }}"
         run_bundle_test: "{{ run_bundle_test | default(true) }}"
         image_protocol: "{{ image_protocol | default('docker://') }}"
-        oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+        oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
       tags:
         - always
         - test

--- a/upstream/roles/index_verify/tasks/main.yml
+++ b/upstream/roles/index_verify/tasks/main.yml
@@ -62,7 +62,7 @@
     msg: "Operators not in sync: '{{ iv_operators_failed | join(',') }}' [{{ iv_operators_failed | length }}/{{ iv_index_operator_ana.keys() | length }}]!!! More info above or in '{{ iv_output_file }}' file"
   when:
     - iv_operators_failed is defined
-    - iv_operators_failed | length
+    - iv_operators_failed | length > 0
 
 - name: "Fail with list of operators that are not in sync"
   ansible.builtin.debug:

--- a/upstream/roles/inject_openshift_kube_objects/tasks/main.yml
+++ b/upstream/roles/inject_openshift_kube_objects/tasks/main.yml
@@ -32,7 +32,7 @@
 
 - name: "Read yaml file content to get the namespace"
   set_fact:
-    content="{{ lookup('file', '{{ kube_objects_dir }}/kube_objects.yaml') | from_yaml }}"
+    content: "{{ lookup('file', kube_objects_dir + '/kube_objects.yaml') | from_yaml }}"
   no_log: true
   ignore_errors: true
 

--- a/upstream/roles/install_operator_prereqs/tasks/main.yml
+++ b/upstream/roles/install_operator_prereqs/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: "Set basic facts"
   set_fact:
     operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
-    oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+    oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
     jq_bin_path: "{{ testing_bin_path }}/jq"
     yq_bin_path: "{{ testing_bin_path }}/yq"
     go_bin_path: "{{ testing_bin_path }}/go/bin/go"

--- a/upstream/roles/test_operator_bundle/tasks/main.yml
+++ b/upstream/roles/test_operator_bundle/tasks/main.yml
@@ -8,7 +8,7 @@
     umoci_bin_path: "{{ testing_bin_path }}/umoci"
     opm_bin_path: "{{ testing_bin_path }}/opm"
     operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
-    oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+    oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
 
 
 - name: "Install operator testing prerequisites"

--- a/upstream/roles/test_operator_manifest/tasks/main.yml
+++ b/upstream/roles/test_operator_manifest/tasks/main.yml
@@ -5,7 +5,7 @@
     scorecard_cr_dir: "{{ work_dir }}/scorecard-cr-files"
     kube_objects_dir: "{{ work_dir }}/kube_objects"
     testing_bin_path: "{{ work_dir }}/bin"
-    oc_bin_path: '{{ ''kubectl'' if run_upstream else "{{ testing_bin_path }}/oc" }}'
+    oc_bin_path: "{{ 'kubectl' if run_upstream else testing_bin_path + '/oc' }}"
     jq_bin_path: "{{ testing_bin_path }}/jq"
     yq_bin_path: "{{ testing_bin_path }}/yq"
     go_bin_path: "{{ testing_bin_path }}/go/bin/go"


### PR DESCRIPTION
Ansible playbooks and tasks were updated based on the [porting guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html) to be compatible with Ansible2.19.

I used simple generated regex matching script to detect lines with possible issues and then reviewed and fixed them manually.
- one issue was caused by [changes in conditions](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html#broken-conditionals)
- other issues were caused by change in [nested templates](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_core_2.19.html#multi-pass-templating)

During the work I also fixed bug with silently failing ansible lint which leads to about 100 issues with one, or 900 issues with other ansible-lint config. I'll be creating separate ticket to address these issues and update linter config.