### PR TITLE
fix(ISV-7433): filter out non-arch artifacts in registry

### DIFF
--- a/upstream/roles/mirror_image/tasks/mirror_single.yml
+++ b/upstream/roles/mirror_image/tasks/mirror_single.yml
@@ -124,7 +124,10 @@
         mi_actual_architectures: []
 
     - name: "Detect architectures from image '{{ mirror_input_image_final }}'"
-      shell: "{{ container_tool }} manifest inspect {{ mirror_input_image_final }} | {{ jq_bin_path }} '.manifests[].platform.architecture' -r"
+      shell: >-
+        {{ container_tool }} manifest inspect {{ mirror_input_image_final }}
+        | {{ jq_bin_path }} -r
+        '.manifests[] | select(.platform.architecture != null and .platform.architecture != "unknown") | .platform.architecture'
       retries: "{{ default_retries }}"
       delay: "{{ default_delay }}"
       register: mi_archs_inspect_result
@@ -232,7 +235,10 @@
                 - quay_arch_input_host|length > 0
 
             - name: "Get list of arch from image '{{ mirror_multiarch_image_final }}'"
-              shell: "{{ container_tool }} manifest inspect {{ mirror_multiarch_image_final }} | {{ jq_bin_path }} '.manifests[].platform.architecture' -r"
+              shell: >-
+                {{ container_tool }} manifest inspect {{ mirror_multiarch_image_final }}
+                | {{ jq_bin_path }} -r
+                '.manifests[] | select(.platform.architecture != null and .platform.architecture != "unknown") | .platform.architecture'
               retries: "{{ default_retries }}"
               delay: "{{ default_delay }}"
               until: archs_inspect_result is not failed

--- a/upstream/roles/multiarch_fbc/tasks/main.yml
+++ b/upstream/roles/multiarch_fbc/tasks/main.yml
@@ -52,13 +52,6 @@
   set_fact:
     multiarch_fbc_architectures: "{{ mfbc_archs_inspect_result.stdout_lines | list }}"
 
-- name: "Filter unsupported architectures"
-  set_fact:
-    multiarch_fbc_architectures: >-
-      {{ multiarch_fbc_architectures
-         | reject('equalto', '')
-         | list }}
-
 - name: "Print archs list'"
   debug:
     var: multiarch_fbc_architectures

--- a/upstream/roles/multiarch_fbc/tasks/main.yml
+++ b/upstream/roles/multiarch_fbc/tasks/main.yml
@@ -42,12 +42,22 @@
     - mfbc_list_architectures_from.startswith('registry.redhat.io')
 
 - name: "Detect needed architectures from image '{{ mfbc_list_architectures_from }}'"
-  shell: "{{ container_tool }} manifest inspect {{ mfbc_list_architectures_from }} | {{ jq_bin_path }} '.manifests[].platform.architecture' -r"
+  shell: >-
+    {{ container_tool }} manifest inspect {{ mfbc_list_architectures_from }}
+    | {{ jq_bin_path }} -r
+    '.manifests[] | select(.platform.architecture != null and .platform.architecture != "unknown") | .platform.architecture'
   register: mfbc_archs_inspect_result
 
 - name: "Parse archs to list"
   set_fact:
     multiarch_fbc_architectures: "{{ mfbc_archs_inspect_result.stdout_lines | list }}"
+
+- name: "Filter unsupported architectures"
+  set_fact:
+    multiarch_fbc_architectures: >-
+      {{ multiarch_fbc_architectures
+         | reject('equalto', '')
+         | list }}
 
 - name: "Print archs list'"
   debug:


### PR DESCRIPTION
This change is needed to support transition to a new version of OPM - architectures are decided based on all artifacts in the repository [like this](https://github.com/k8s-operatorhub/community-operators/actions/runs/29209144008/job/86693972307#step:3:4763) and fail on non-arch items like SBOMs or attestations with `unknown` arch (failure example [here](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline/actions/runs/26947797095/job/79505268770#step:3:3264)). This PR filters out unknown and empty arches.

Only the second change in mirror_single.yml is actually needed, the first change is kept for parity in logic.

Tested locally with newest OPM using updated operator-test-playbooks.


Assisted-by: Cursor