### PR TITLE
fix(ISV-7651) Fix xargs parsing after fedora upgrade

### DIFF
--- a/upstream/roles/deploy_olm_operator_upstream_bundle/tasks/main.yml
+++ b/upstream/roles/deploy_olm_operator_upstream_bundle/tasks/main.yml
@@ -185,7 +185,7 @@
     - operator_result.rc != 0 or operator_uptime_raw_rc|int != 0 or operator_uptime_raw_rc is not defined
 
 - name: "Get the pod status of the deployed operator"
-  shell: '{{ oc_bin_path }} get --output=name pods {{ upstream_namespace_param }}| grep -- {{ operator_pod_name | quote }} | cut -f1 | xargs -I{} {{ oc_bin_path }} get {} {{ upstream_namespace_param }} -o yaml | {{ yq_bin_path }} r - "status"'
+  shell: "{{ oc_bin_path }} get --output=name pods {{ upstream_namespace_param }}| grep -F {{ operator_pod_name | quote }} | tr '\\n' '\\0' | xargs -0 -I{} {{ oc_bin_path }} get {} {{ upstream_namespace_param }} -o yaml | {{ yq_bin_path }} r - \"status\""
   register: operator_pod_result
   ignore_errors: true
   environment:
@@ -211,7 +211,7 @@
     - operator_result.rc != 0 or operator_uptime_raw_rc|int != 0 or operator_uptime_raw_rc is not defined
 
 - name: "Get the pod container logs of the deployed operator"
-  shell: "{{ oc_bin_path }} get --output=name pods {{ upstream_namespace_param }}| grep -- {{ operator_pod_name | quote }} | cut -d' ' -f1 | xargs -I{} {{ oc_bin_path }} logs {} -c {{ operator_container_name | quote }} {{ upstream_namespace_param }}"
+  shell: "{{ oc_bin_path }} get --output=name pods {{ upstream_namespace_param }}| grep -F {{ operator_pod_name | quote }} | cut -d' ' -f1 | tr '\\n' '\\0' | xargs -0 -I{} {{ oc_bin_path }} logs {} -c {{ operator_container_name | quote }} {{ upstream_namespace_param }}"
   register: operator_container_result
   ignore_errors: true
   environment:


### PR DESCRIPTION
Combination of recent changes broke parsing in xargs command in k8s release pipeline.

Addition of quotes from ISV-7497 worked fine on older fedora, but after upgrade to Fedora 44, `xargs` has different behavior and additional quotes breaks it.

This should be fixed by using xargs with `-0` param to read quotes as literals. This change requires also replacing newlines with `\0` because `xargs -0` expects null byte as a delimiter and ignores newlines.